### PR TITLE
Update to cloc 1.88

### DIFF
--- a/.profile.d/add_env_vars.sh
+++ b/.profile.d/add_env_vars.sh
@@ -1,2 +1,0 @@
-# Add cloc to PATH
-export PATH=$PATH:$HOME/vendor/bin

--- a/.profile.d/add_env_vars.sh
+++ b/.profile.d/add_env_vars.sh
@@ -1,2 +1,2 @@
 # Add cloc to PATH
-export PATH="$PATH:$HOME/vendor/cloc"
+export PATH=$PATH:$HOME/vendor/bin

--- a/.profile.d/add_env_vars.sh
+++ b/.profile.d/add_env_vars.sh
@@ -1,0 +1,2 @@
+# Add cloc to PATH
+export PATH="$PATH:$HOME/vendor/cloc"

--- a/bin/compile
+++ b/bin/compile
@@ -1,21 +1,21 @@
 #!/usr/bin/env bash
 
-echo "-----> Installing cloc 1.8.4"
+echo "-----> Installing cloc 1.8.8"
 
 # change to the the BUILD_DIR ($1)
 cd $1
 
 # download the binary (-O) silently (-s)
-curl -L https://github.com/AlDanial/cloc/releases/download/1.84/cloc-1.84.tar.gz -s -O
+curl -L https://github.com/AlDanial/cloc/releases/download/1.88/cloc-1.88.tar.gz -s -O
 
-# make a directory to untar (like unzip) the binary
+# make a directory to place the binary
 mkdir -p vendor/cloc
 
 # untar cloc
-tar -xvf cloc-1.84.tar.gz
+tar -xvf cloc-1.88.tar.gz
 
 # Move the binary
-mv cloc-1.84/cloc vendor/bin/
+mv cloc-1.88/cloc vendor/cloc/
 
 # clean up after ourselves
-rm -rf cloc-1.84*
+rm -rf cloc-1.88*

--- a/bin/compile
+++ b/bin/compile
@@ -17,8 +17,5 @@ tar -xvf cloc-1.88.tar.gz
 # Move the binary
 mv cloc-1.88/cloc vendor/cloc/
 
-# Add cloc to PATH
-export PATH="$PATH:$HOME/vendor/cloc"
-
 # clean up after ourselves
 rm -rf cloc-1.88*

--- a/bin/compile
+++ b/bin/compile
@@ -17,5 +17,8 @@ tar -xvf cloc-1.88.tar.gz
 # Move the binary
 mv cloc-1.88/cloc vendor/cloc/
 
+# Add cloc to PATH
+export PATH="$PATH:$HOME/vendor/cloc"
+
 # clean up after ourselves
 rm -rf cloc-1.88*

--- a/bin/compile
+++ b/bin/compile
@@ -12,7 +12,7 @@ curl -L https://github.com/AlDanial/cloc/releases/download/1.88/cloc-1.88.tar.gz
 mkdir -p vendor/cloc
 
 # untar cloc
-tar -xvf cloc-1.88.tar.gz
+tar -xf cloc-1.88.tar.gz
 
 # Move the binary
 mv cloc-1.88/cloc vendor/cloc/

--- a/bin/compile
+++ b/bin/compile
@@ -4,8 +4,10 @@ echo "-----> Installing cloc 1.8.8"
 
 # change to the the BUILD_DIR ($1)
 cd $1
+BUILD_DIR=$1
 
 # download the binary (-O) silently (-s)
+echo "       - Downloading CLOC"
 curl -L https://github.com/AlDanial/cloc/releases/download/1.88/cloc-1.88.tar.gz -s -O
 
 # make a directory to place the binary
@@ -15,9 +17,20 @@ mkdir -p vendor/bin
 tar -xf cloc-1.88.tar.gz
 
 # Move the binary
+echo "       - Moving binary file"
 mv cloc-1.88/cloc vendor/bin/
 
+# Writing profile script to add binary dir to PATH
+echo "       - Setting PATH"
+mkdir -p $BUILD_DIR/.profile.d
+cat <<EOF >$BUILD_DIR/.profile.d/add-env-vars.sh
+export PATH="\$HOME/vendor/bin:\$PATH"
+EOF
+
+export PATH="$BUILD_DIR/vendor/bin:$PATH"
+
 # clean up after ourselves
+echo "       - Cleaning up"
 rm -rf cloc-1.88*
 
 echo "-----> cloc 1.8.8 installed!"

--- a/bin/compile
+++ b/bin/compile
@@ -9,13 +9,15 @@ cd $1
 curl -L https://github.com/AlDanial/cloc/releases/download/1.88/cloc-1.88.tar.gz -s -O
 
 # make a directory to place the binary
-mkdir -p vendor/cloc
+mkdir -p vendor/bin
 
 # untar cloc
 tar -xf cloc-1.88.tar.gz
 
 # Move the binary
-mv cloc-1.88/cloc vendor/cloc/
+mv cloc-1.88/cloc vendor/bin/
 
 # clean up after ourselves
 rm -rf cloc-1.88*
+
+echo "-----> cloc 1.8.8 installed!"

--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-echo "cloc 1.8.4"
+echo "cloc 1.8.8"
 exit 0

--- a/bin/release
+++ b/bin/release
@@ -1,7 +1,3 @@
 #!/usr/bin/env bash
 
-cat <<EOF
----
-config_vars:
-  PATH: $PATH:/app/vendor/cloc
-EOF
+echo "--- {}"

--- a/bin/release
+++ b/bin/release
@@ -3,5 +3,5 @@
 cat <<EOF
 ---
 config_vars:
-  PATH: $PATH:/app/vendor/cloc/bin
+  PATH: $PATH:/app/vendor/cloc
 EOF


### PR DESCRIPTION
Changes included in this PR:
- Update cloc to version 1.88
- Add messages during installation
- Creates a profile script (`.profile.d/add-env-vars.sh`) 
- Sets PATH to include the `vendor/bin` directory

I could not get the previous version of the buildpack to work with Buffy, updating it with all these changes made it work just adding the buildpack to the heroku app.